### PR TITLE
Install node exporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ RUN npm run build
 
 # Production stage
 FROM nginx:1.25-alpine AS production
+RUN apk add --no-cache curl tar
+ARG NODE_EXPORTER_VERSION=1.9.1
+RUN curl -L https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz \
+        | tar xz && \
+    mv node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64/node_exporter /usr/local/bin/ && \
+    rm -r node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64 && \
+    apk del curl tar
 COPY --from=build /app/dist /usr/share/nginx/html
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+EXPOSE 80 9100
+CMD ["/bin/sh", "-c", "node_exporter & nginx -g 'daemon off;'" ]

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 This template should help get you started developing with Vue 3 in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
 
 Learn more about IDE Support for Vue in the [Vue Docs Scaling up Guide](https://vuejs.org/guide/scaling-up/tooling.html#ide-support).
+
+## Metrics export
+
+The container embeds a [Prometheus Node Exporter](https://github.com/prometheus/node_exporter) instance to expose
+system metrics on port `9100`. These metrics can be scraped by an existing Prometheus server.


### PR DESCRIPTION
## Summary
- install Prometheus node_exporter in the Docker image
- document metrics export via README

## Testing
- `npm run lint` *(fails: ban-ts-comment, no-unused-vars, no-explicit-any)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866c21df2ec832bbcb14ca27abdba4a