### PR TITLE
Install Alloy for log forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:18-alpine AS build
+FROM node:18 AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
@@ -7,14 +7,20 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM nginx:1.25-alpine AS production
-RUN apk add --no-cache curl tar
+FROM nginx:1.25 AS production
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates tar unzip \
+    && rm -rf /var/lib/apt/lists/*
 ARG NODE_EXPORTER_VERSION=1.9.1
+ARG ALLOY_VERSION=1.9.2
 RUN curl -L https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz \
         | tar xz && \
     mv node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64/node_exporter /usr/local/bin/ && \
     rm -r node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64 && \
-    apk del curl tar
+    curl -L https://github.com/grafana/alloy/releases/download/v${ALLOY_VERSION}/alloy-linux-amd64.zip -o alloy.zip && \
+    unzip alloy.zip && mv alloy-linux-amd64 /usr/local/bin/alloy && rm alloy.zip && \
+    apt-get purge -y --auto-remove curl ca-certificates tar unzip && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/dist /usr/share/nginx/html
-EXPOSE 80 9100
-CMD ["/bin/sh", "-c", "node_exporter & nginx -g 'daemon off;'" ]
+COPY alloy.yaml /etc/alloy/config.yaml
+EXPOSE 80 9100 12345
+CMD ["/bin/sh", "-c", "node_exporter & /usr/local/bin/alloy --config.file=/etc/alloy/config.yaml & nginx -g 'daemon off;'" ]

--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ Learn more about IDE Support for Vue in the [Vue Docs Scaling up Guide](https://
 
 The container embeds a [Prometheus Node Exporter](https://github.com/prometheus/node_exporter) instance to expose
 system metrics on port `9100`. These metrics can be scraped by an existing Prometheus server.
+
+## Logs export
+
+The image includes [Grafana Alloy](https://grafana.com/docs/alloy/latest/) to forward
+system and Nginx logs to a Loki instance. Configure the `LOKI_URL` environment variable
+with the Loki push URL when running the container.

--- a/alloy.yaml
+++ b/alloy.yaml
@@ -1,0 +1,19 @@
+logging {
+  level = "info"
+}
+
+loki.source.file "system" {
+  targets = [{__path__ = "/var/log/*.log", job = "system"}]
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.source.file "nginx" {
+  targets = [{__path__ = "/var/log/nginx/*.log", job = "nginx"}]
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+  endpoint {
+    url = "${LOKI_URL}"
+  }
+}


### PR DESCRIPTION
## Summary
- install Alloy log agent and add config file
- forward system and nginx logs to an existing Loki instance
- document logging configuration in README

## Testing
- `npm install`
- `npm run lint` *(fails: ban-ts-comment, no-unused-vars, no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_6866f8e6de64832b9550e88620130912